### PR TITLE
Fix Uncaught TypeError on view: "`intl` is undefined".

### DIFF
--- a/news/27.bugfix
+++ b/news/27.bugfix
@@ -1,0 +1,2 @@
+Fix Uncaught TypeError on view: "`intl` is undefined".
+@mauritsvanrees

--- a/src/components/View.jsx
+++ b/src/components/View.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import config from '@plone/volto/registry';
+import { useSelector } from 'react-redux';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import { DetachedTextBlockEditor } from '@plone/volto-slate/blocks/Text/DetachedTextBlockEditor';
 import { TextBlockView } from '@plone/volto-slate/blocks/Text';
 
 const View = (props) => {
-  const { data, isEditMode, intl } = props;
+  const { data, isEditMode } = props;
+  const intl = useSelector((state) => state.intl);
 
   const customSlateSettings = {
     ...props,


### PR DESCRIPTION
Fixes issue #27.

Works for me on Volto 18 alpha 42 with volto-light-theme 5.0.0.